### PR TITLE
Add host-network start script and update readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,25 @@ For full functionality, valid and activated licenses are required. See official 
 To manage the containers we do provide a few docker scripts to use as is or to draw inspiration from:
 [user-scripts](./user-scripts)
 
+After downloading the image with `docker pull`, start the Enterprise Server
+using the provided script or the command shown below.
+
+```bash
+./user-scripts/start-host-es.sh
+```
+
+This script simply runs:
+```bash
+docker run -d --network host \
+    --platform linux/amd64 \
+    --ulimit core=-1 \
+    --restart always \
+    --mount type=bind,source=/var/crash,target=/var/crash \
+    -e NSP_ACCEPT_EULA="Yes" \
+    --mount source=EnterpriseServer-db,target=/var/EBO \
+    ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
+```
+
 ### Network
 We recommend that you use this container with an IPvlan network. This to give the container its own IP address on the local network for simple communication with for example BACnet devices on the same network.
 
@@ -123,7 +142,7 @@ docker run -d --network host \
     --restart always \
     --mount type=bind,source=/var/crash,target=/var/crash \
     -e NSP_ACCEPT_EULA="Yes" \
-    --mount source=cs3-db,target=/var/sbo \
+    --mount source=EnterpriseServer-db,target=/var/EBO \
     ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
 ```
 

--- a/user-scripts/start-host-es.sh
+++ b/user-scripts/start-host-es.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Simple helper to start Enterprise Server using host networking
+# After pulling the image, run this script to start the container
+
+docker run -d --network host \
+    --platform linux/amd64 \
+    --ulimit core=-1 \
+    --restart always \
+    --mount type=bind,source=/var/crash,target=/var/crash \
+    -e NSP_ACCEPT_EULA="Yes" \
+    --mount source=EnterpriseServer-db,target=/var/EBO \
+    ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
+


### PR DESCRIPTION
## Summary
- document starting the container after pulling the image
- provide helper script to launch Enterprise Server using host networking
- update direct `docker run` example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aeb0541188330984d40cb2ef14b15