### PR TITLE
Document crash folder and auto-create in start script

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,13 @@ docker run -d --network host \
     --mount type=bind,source=/var/crash,target=/var/crash \
     -e NSP_ACCEPT_EULA="Yes" \
     --mount source=EnterpriseServer-db,target=/var/EBO \
-    ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
+ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
+```
+
+Before running the script, make sure `/var/crash` exists on the host:
+
+```bash
+sudo mkdir -p /var/crash
 ```
 
 ### Network

--- a/user-scripts/start-host-es.sh
+++ b/user-scripts/start-host-es.sh
@@ -2,6 +2,12 @@
 # Simple helper to start Enterprise Server using host networking
 # After pulling the image, run this script to start the container
 
+# Ensure crash dump folder exists
+if [ ! -d /var/crash ]; then
+    echo "Creating /var/crash"
+    sudo mkdir -p /var/crash
+fi
+
 docker run -d --network host \
     --platform linux/amd64 \
     --ulimit core=-1 \


### PR DESCRIPTION
## Summary
- describe startup steps in README for `/var/crash`
- auto-create `/var/crash` in `start-host-es.sh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684af3e2dde083309db4c1e6ac4e1c86