### PR TITLE
Fix README start section example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,13 +152,15 @@ To start an Enterprise Server or Enterprise Central instead. add --type=ebo-ente
 
 If you prefer running Docker directly:
 ```bash
-docker run -d --network host \
-    --platform linux/amd64 \
+docker run -d --platform linux/amd64 \
+    --name=cs3 -h cs3 \
     --ulimit core=-1 \
     --restart always \
+    --network bridged-net \
+    --ip 192.168.1.3 \
     --mount type=bind,source=/var/crash,target=/var/crash \
     -e NSP_ACCEPT_EULA="Yes" \
-    --mount source=EnterpriseServer-db,target=/var/EBO \
+    --mount source=cs3-db,target=/var/sbo \
     ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
 ```
 


### PR DESCRIPTION
## Summary
- update manual `docker run` example under **Start** to match `start.py`

## Testing
- `python3 -m py_compile user-scripts/start.py`

------
https://chatgpt.com/codex/tasks/task_e_684b328370a8833092b927a7d494a9e0