### PR TITLE
Add Docker Swarm option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ After downloading the image with `docker pull`, start the Enterprise Server
 using the provided script or the command shown below.
 
 ```bash
-./user-scripts/start-host-es.sh
+./user-scripts/start-host-es.sh [--swarm]
 ```
 
 This script simply runs:
@@ -81,6 +81,7 @@ docker run -d --network bridged-net \
     --mount source=EnterpriseServer-db,target=/var/EBO \
 ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
 ```
+When called with `--swarm`, the script creates an equivalent `docker service`.
 
 Before running the script, make sure `/var/crash` exists on the host:
 
@@ -191,7 +192,7 @@ The End-User License Agreement (EULA) must be accepted before the server can sta
 
 Then to start your server:
 ```
-./start.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes
+./start.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--swarm]
 ```
 You can interact with the server via your browser: https://192.168.1.3/.
 Initial user name: admin, password: admin
@@ -216,7 +217,7 @@ docker run -d --platform linux/amd64 --name=cs3 -h cs3 \
 To upgrade the server, use the same parameters as for start, but with the new version.
 
 ```
-./upgrade.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes
+./upgrade.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--swarm]
 ```
 The version and IP are only examples
 ### Backup management
@@ -353,6 +354,30 @@ The http-port is 1080 on the host machine.
 The tcp-port is 14444 on the host machine.
 It runs the example version 7.0.2.348.
 It is namned cs1.
+
+## Docker Swarm
+Docker Swarm allows you to manage multiple Raspberry Pi nodes as a single cluster.
+Initialize the swarm on the master node:
+```bash
+docker swarm init --advertise-addr <IP_of_master>
+```
+Join additional nodes as workers using the join token printed by the init command:
+```bash
+docker swarm join --token <token> <IP_of_master>:2377
+```
+To start the Enterprise Server as a swarm service use the scripts with the `--swarm` option.
+```bash
+./user-scripts/start-host-es.sh --swarm
+./start.py --swarm --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --accept-eula=Yes
+```
+Remove a node from the cluster with:
+```bash
+docker swarm leave
+```
+Services can be scaled with:
+```bash
+docker service scale <service>=<N>
+```
 
 ## GraphDB
 For containers we use the standard GraphDB from https://hub.docker.com/r/ontotext/graphdb/ to get a license contact https://www.ontotext.com/.

--- a/user-scripts/start-graphdb
+++ b/user-scripts/start-graphdb
@@ -1,11 +1,14 @@
 #!/bin/bash
 
 # arguments
-# $1 ip
+# $1 ip or --swarm
 ip=$1
 name=graphdb
 
-
-docker run -d --name=$name --restart always -h $name --ip $ip --network bridged-net ontotext/graphdb:10.2.4
-sleep 10
-docker logs $name
+if [ "$1" = "--swarm" ]; then
+    docker service create --name=$name --hostname $name --network bridged-net ontotext/graphdb:10.2.4
+else
+    docker run -d --name=$name --restart always -h $name --ip $ip --network bridged-net ontotext/graphdb:10.2.4
+    sleep 10
+    docker logs $name
+fi

--- a/user-scripts/start-host-es.sh
+++ b/user-scripts/start-host-es.sh
@@ -8,12 +8,24 @@ if [ ! -d /var/crash ]; then
     sudo mkdir -p /var/crash
 fi
 
-docker run -d --network bridged-net \
-    --platform linux/amd64 \
-    --ulimit core=-1 \
-    --restart always \
-    --mount type=bind,source=/var/crash,target=/var/crash \
-    -e NSP_ACCEPT_EULA="Yes" \
-    --mount source=EnterpriseServer-db,target=/var/EBO \
-    ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
+if [ "$1" = "--swarm" ]; then
+    shift
+    docker service create --name enterprise-server \
+        --hostname enterprise-server \
+        --network bridged-net \
+        --platform linux/amd64 \
+        --mount type=bind,source=/var/crash,target=/var/crash \
+        -e NSP_ACCEPT_EULA="Yes" \
+        --mount source=EnterpriseServer-db,target=/var/EBO \
+        ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
+else
+    docker run -d --network bridged-net \
+        --platform linux/amd64 \
+        --ulimit core=-1 \
+        --restart always \
+        --mount type=bind,source=/var/crash,target=/var/crash \
+        -e NSP_ACCEPT_EULA="Yes" \
+        --mount source=EnterpriseServer-db,target=/var/EBO \
+        ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
+fi
 

--- a/user-scripts/start.py
+++ b/user-scripts/start.py
@@ -34,6 +34,7 @@ def get_arguments(description):
         "if not given the host environment variables https_proxy or HTTPS_PROXY will be used ")
     parser.add_argument('--no-proxy', default=None, help="optional no proxy " \
         "if not given the host environment variables no_proxy or NO_PROXY will be used ")
+    parser.add_argument('--swarm', action='store_true', help='create a Docker service instead of a standalone container')
     return parser.parse_args()
 
 def run():
@@ -75,19 +76,29 @@ def run():
         if "NO_PROXY" in os.environ:
             proxy += f'-e NO_PROXY={os.environ["NO_PROXY"]} '
 
-    cmd = f'docker run -d --platform linux/amd64 --name={name} -h {name} ' \
-        '--ulimit core=-1 ' \
-        '--restart always ' \
-        '--network bridged-net ' \
-        f'--mount type=bind,source=/var/crash,target=/var/crash ' \
-        f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
-        f'-e Semantic_Db_URL="{graphdb}" ' \
-        f'{proxy}'\
-        f'--ip {ip} ' \
-        f'--mount source={db_vol},target={db_folder} '
+    if args.swarm:
+        cmd = f'docker service create --name={name} --hostname {name} ' \
+            '--network bridged-net ' \
+            '--platform linux/amd64 ' \
+            f'--mount type=bind,source=/var/crash,target=/var/crash ' \
+            f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
+            f'-e Semantic_Db_URL="{graphdb}" ' \
+            f'{proxy}'\
+            f'--mount source={db_vol},target={db_folder} '
+    else:
+        cmd = f'docker run -d --platform linux/amd64 --name={name} -h {name} ' \
+            '--ulimit core=-1 ' \
+            '--restart always ' \
+            '--network bridged-net ' \
+            f'--mount type=bind,source=/var/crash,target=/var/crash ' \
+            f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
+            f'-e Semantic_Db_URL="{graphdb}" ' \
+            f'{proxy}'\
+            f'--ip {ip} ' \
+            f'--mount source={db_vol},target={db_folder} '
     if ca_folder:
         cmd += f'--mount type=bind,source={ca_folder},target=/usr/local/share/ca-certificates '
-    if dns:
+    if dns and not args.swarm:
         cmd += f'--dns {dns} '
     cmd += image
     exe(cmd)

--- a/user-scripts/teststart.py
+++ b/user-scripts/teststart.py
@@ -34,6 +34,7 @@ def get_arguments(description):
         "if not given the host environment variables https_proxy or HTTPS_PROXY will be used ")
     parser.add_argument('--no-proxy', default=None, help="optional no proxy " \
         "if not given the host environment variables no_proxy or NO_PROXY will be used ")
+    parser.add_argument('--swarm', action='store_true', help='create a Docker service instead of a standalone container')
     return parser.parse_args()
 
 def run():
@@ -76,17 +77,26 @@ def run():
         if "NO_PROXY" in os.environ:
             proxy += f'-e NO_PROXY={os.environ["NO_PROXY"]} '
 
-    cmd = f'docker run -d --platform linux/amd64 --name={name} -h {name} ' \
-        '--ulimit core=-1 ' \
-        '--network bridged-net ' \
-        f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
-        f'-e Semantic_Db_URL="{graphdb}" ' \
-        f'{proxy}'\
-        f'--ip {ip} ' \
-        f'--mount source={db_vol},target={db_folder} '
+    if args.swarm:
+        cmd = f'docker service create --name={name} --hostname {name} ' \
+            '--network bridged-net ' \
+            '--platform linux/amd64 ' \
+            f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
+            f'-e Semantic_Db_URL="{graphdb}" ' \
+            f'{proxy}'\
+            f'--mount source={db_vol},target={db_folder} '
+    else:
+        cmd = f'docker run -d --platform linux/amd64 --name={name} -h {name} ' \
+            '--ulimit core=-1 ' \
+            '--network bridged-net ' \
+            f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
+            f'-e Semantic_Db_URL="{graphdb}" ' \
+            f'{proxy}'\
+            f'--ip {ip} ' \
+            f'--mount source={db_vol},target={db_folder} '
     if ca_folder:
         cmd += f'--mount type=bind,source={ca_folder},target=/usr/local/share/ca-certificates '
-    if dns:
+    if dns and not args.swarm:
         cmd += f'--dns {dns} '
     cmd += image
     exe(cmd)


### PR DESCRIPTION
## Summary
- add `--swarm` support to helper scripts
- document Docker Swarm usage and options in the README

## Testing
- `python3 -m py_compile user-scripts/start.py user-scripts/teststart.py user-scripts/restore-backup`
- `python3 -m py_compile user-scripts/upgrade.py`


------
https://chatgpt.com/codex/tasks/task_e_684af64874c483308df20139cf011771