### PR TITLE
Fallback for service create without platform flag

### DIFF
--- a/user-scripts/start-host-es.sh
+++ b/user-scripts/start-host-es.sh
@@ -10,10 +10,15 @@ fi
 
 if [ "$1" = "--swarm" ]; then
     shift
+    if docker service create --help 2>&1 | grep -q -- "--platform"; then
+        PLATFORM_OPTION="--platform linux/amd64"
+    else
+        PLATFORM_OPTION=""
+    fi
     docker service create --name enterprise-server \
         --hostname enterprise-server \
         --network bridged-net \
-        --platform linux/amd64 \
+        $PLATFORM_OPTION \
         --mount type=bind,source=/var/crash,target=/var/crash \
         -e NSP_ACCEPT_EULA="Yes" \
         --mount source=EnterpriseServer-db,target=/var/EBO \

--- a/user-scripts/start.py
+++ b/user-scripts/start.py
@@ -77,9 +77,17 @@ def run():
             proxy += f'-e NO_PROXY={os.environ["NO_PROXY"]} '
 
     if args.swarm:
+        platform_option = ''
+        try:
+            help_text = exe('docker service create --help')
+            if '--platform' in help_text:
+                platform_option = '--platform linux/amd64 '
+        except Exception:
+            pass
+
         cmd = f'docker service create --name={name} --hostname {name} ' \
             '--network bridged-net ' \
-            '--platform linux/amd64 ' \
+            f'{platform_option}' \
             f'--mount type=bind,source=/var/crash,target=/var/crash ' \
             f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
             f'-e Semantic_Db_URL="{graphdb}" ' \

--- a/user-scripts/teststart.py
+++ b/user-scripts/teststart.py
@@ -78,9 +78,17 @@ def run():
             proxy += f'-e NO_PROXY={os.environ["NO_PROXY"]} '
 
     if args.swarm:
+        platform_option = ''
+        try:
+            help_text = exe('docker service create --help')
+            if '--platform' in help_text:
+                platform_option = '--platform linux/amd64 '
+        except Exception:
+            pass
+
         cmd = f'docker service create --name={name} --hostname {name} ' \
             '--network bridged-net ' \
-            '--platform linux/amd64 ' \
+            f'{platform_option}' \
             f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
             f'-e Semantic_Db_URL="{graphdb}" ' \
             f'{proxy}'\


### PR DESCRIPTION
## Summary
- ensure `start.py` and `teststart.py` don't fail on older Docker versions without `--platform` support
- add the same check to `start-host-es.sh`

## Testing
- `python3 -m py_compile user-scripts/start.py user-scripts/teststart.py`
- `bash -n user-scripts/start-host-es.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ff2021ed08330a4635e386e8028a9