### PR TITLE
Add network option to startup scripts

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,12 +67,12 @@ After downloading the image with `docker pull`, start the Enterprise Server
 using the provided script or the command shown below.
 
 ```bash
-./user-scripts/start-host-es.sh [--swarm]
+./user-scripts/start-host-es.sh [--swarm] [--network <net>]
 ```
 
 This script simply runs:
 ```bash
-docker run -d --network bridged-net \
+docker run -d --network <net> \
     --platform linux/amd64 \
     --ulimit core=-1 \
     --restart always \
@@ -192,7 +192,7 @@ The End-User License Agreement (EULA) must be accepted before the server can sta
 
 Then to start your server:
 ```
-./start.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--swarm]
+./start.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--swarm] [--network <net>]
 ```
 You can interact with the server via your browser: https://192.168.1.3/.
 Initial user name: admin, password: admin
@@ -205,7 +205,7 @@ If you prefer running Docker directly:
 docker run -d --platform linux/amd64 --name=cs3 -h cs3 \
     --ulimit core=-1 \
     --restart always \
-    --network bridged-net \
+    --network <net> \
     --mount type=bind,source=/var/crash,target=/var/crash \
     -e NSP_ACCEPT_EULA="Yes" \
     --ip 192.168.1.3 \
@@ -217,7 +217,7 @@ docker run -d --platform linux/amd64 --name=cs3 -h cs3 \
 To upgrade the server, use the same parameters as for start, but with the new version.
 
 ```
-./upgrade.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--swarm]
+./upgrade.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--swarm] [--network <net>]
 ```
 The version and IP are only examples
 ### Backup management
@@ -368,7 +368,7 @@ docker swarm join --token <token> <IP_of_master>:2377
 To start the Enterprise Server as a swarm service use the scripts with the `--swarm` option.
 ```bash
 ./user-scripts/start-host-es.sh --swarm
-./start.py --swarm --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --accept-eula=Yes
+./start.py --swarm --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --accept-eula=Yes [--network <net>]
 ```
 Remove a node from the cluster with:
 ```bash

--- a/user-scripts/start-host-es.sh
+++ b/user-scripts/start-host-es.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
-# Simple helper to start Enterprise Server using the bridged-net network
-# After pulling the image, run this script to start the container
+# Simple helper to start Enterprise Server using Docker.
+# After pulling the image, run this script to start the container.
+#
+# Usage:
+#   ./start-host-es.sh [--swarm] [--network <net>]
+#
+# By default the script attaches the container to the "bridged-net" network.
 
 # Ensure crash dump folder exists
 if [ ! -d /var/crash ]; then
@@ -8,23 +13,44 @@ if [ ! -d /var/crash ]; then
     sudo mkdir -p /var/crash
 fi
 
-if [ "$1" = "--swarm" ]; then
-    shift
+NAME="enterprise-server"
+NETWORK="bridged-net"
+SWARM=0
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --swarm)
+            SWARM=1
+            shift
+            ;;
+        --network)
+            NETWORK="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 [--swarm] [--network <net>]"
+            exit 1
+            ;;
+    esac
+done
+
+if [ $SWARM -eq 1 ]; then
     if docker service create --help 2>&1 | grep -q -- "--platform"; then
         PLATFORM_OPTION="--platform linux/amd64"
     else
         PLATFORM_OPTION=""
     fi
-    docker service create --name enterprise-server \
-        --hostname enterprise-server \
-        --network bridged-net \
+    docker service create --name "$NAME" \
+        --hostname "$NAME" \
+        --network "$NETWORK" \
         $PLATFORM_OPTION \
         --mount type=bind,source=/var/crash,target=/var/crash \
         -e NSP_ACCEPT_EULA="Yes" \
         --mount source=EnterpriseServer-db,target=/var/EBO \
         ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
 else
-    docker run -d --network bridged-net \
+    docker run -d --network "$NETWORK" \
         --platform linux/amd64 \
         --ulimit core=-1 \
         --restart always \

--- a/user-scripts/start.py
+++ b/user-scripts/start.py
@@ -28,6 +28,7 @@ def get_arguments(description):
         'containers get their ca certificates')
     parser.add_argument('--dns', default=None, help="optional dns server" \
         "address for when container can't reach host dns, because of, for example, VPN")
+    parser.add_argument('--network', default='bridged-net', help='Docker network to attach to')
     parser.add_argument('--http-proxy', default=None, help="optional http proxy " \
         "if not given the host environment variables http_proxy or HTTP_PROXY will be used ")
     parser.add_argument('--https-proxy', default=None, help="optional https proxy " \
@@ -46,6 +47,7 @@ def run():
     ca_folder = args.ca_folder
     graphdb = args.graphdb
     server_type = args.type
+    network = args.network
     dns = args.dns
     http_proxy=args.http_proxy
     https_proxy=args.https_proxy
@@ -86,7 +88,7 @@ def run():
             pass
 
         cmd = f'docker service create --name={name} --hostname {name} ' \
-            '--network bridged-net ' \
+            f'--network {network} ' \
             f'{platform_option}' \
             f'--mount type=bind,source=/var/crash,target=/var/crash ' \
             f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
@@ -97,7 +99,7 @@ def run():
         cmd = f'docker run -d --platform linux/amd64 --name={name} -h {name} ' \
             '--ulimit core=-1 ' \
             '--restart always ' \
-            '--network bridged-net ' \
+            f'--network {network} ' \
             f'--mount type=bind,source=/var/crash,target=/var/crash ' \
             f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
             f'-e Semantic_Db_URL="{graphdb}" ' \


### PR DESCRIPTION
## Summary
- let `start-host-es.sh` accept `--network` and improve CLI
- allow selecting Docker network in `start.py`
- update docs to show `--network` option

## Testing
- `python3 -m py_compile user-scripts/start.py user-scripts/upgrade.py`
- `bash -n user-scripts/start-host-es.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851cc9e686c8330ad969fe07e76dc13