### PR TITLE
Remove swarm support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ After downloading the image with `docker pull`, start the Enterprise Server
 using the provided script or the command shown below.
 
 ```bash
-./user-scripts/start-host-es.sh [--swarm] [--network <net>]
+./user-scripts/start-host-es.sh [--network <net>]
 ```
 
 This script simply runs:
@@ -69,7 +69,6 @@ docker run -d --network <net> \
     --mount source=EnterpriseServer-db,target=/var/EBO \
 ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
 ```
-When called with `--swarm`, the script creates an equivalent `docker service`.
 
 Before running the script, make sure `/var/crash` exists on the host:
 
@@ -180,7 +179,7 @@ The End-User License Agreement (EULA) must be accepted before the server can sta
 
 Then to start your server:
 ```
-./start.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--swarm] [--network <net>]
+./start.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--network <net>]
 ```
 You can interact with the server via your browser: https://192.168.1.3/.
 Initial user name: admin, password: admin
@@ -205,7 +204,7 @@ docker run -d --platform linux/amd64 --name=cs3 -h cs3 \
 To upgrade the server, use the same parameters as for start, but with the new version.
 
 ```
-./upgrade.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--swarm] [--network <net>]
+./upgrade.py --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --type=ebo-enterprise-server --accept-eula=Yes [--network <net>]
 ```
 The version and IP are only examples
 ### Backup management
@@ -343,29 +342,6 @@ The tcp-port is 14444 on the host machine.
 It runs the example version 7.0.2.348.
 It is namned cs1.
 
-## Docker Swarm
-Docker Swarm allows you to manage multiple Raspberry Pi nodes as a single cluster.
-Initialize the swarm on the master node:
-```bash
-docker swarm init --advertise-addr <IP_of_master>
-```
-Join additional nodes as workers using the join token printed by the init command:
-```bash
-docker swarm join --token <token> <IP_of_master>:2377
-```
-To start the Enterprise Server as a swarm service use the scripts with the `--swarm` option.
-```bash
-./user-scripts/start-host-es.sh --swarm
-./start.py --swarm --name=cs3 --version=7.0.2.348 --ip=192.168.1.3 --accept-eula=Yes [--network <net>]
-```
-Remove a node from the cluster with:
-```bash
-docker swarm leave
-```
-Services can be scaled with:
-```bash
-docker service scale <service>=<N>
-```
 
 ## GraphDB
 For containers we use the standard GraphDB from https://hub.docker.com/r/ontotext/graphdb/ to get a license contact https://www.ontotext.com/.

--- a/user-scripts/start-graphdb
+++ b/user-scripts/start-graphdb
@@ -1,14 +1,10 @@
 #!/bin/bash
 
 # arguments
-# $1 ip or --swarm
+# $1 ip address
 ip=$1
 name=graphdb
 
-if [ "$1" = "--swarm" ]; then
-    docker service create --name=$name --hostname $name --network bridged-net ontotext/graphdb:10.2.4
-else
-    docker run -d --name=$name --restart always -h $name --ip $ip --network bridged-net ontotext/graphdb:10.2.4
-    sleep 10
-    docker logs $name
-fi
+docker run -d --name=$name --restart always -h $name --ip $ip --network bridged-net ontotext/graphdb:10.2.4
+sleep 10
+docker logs $name

--- a/user-scripts/start-host-es.sh
+++ b/user-scripts/start-host-es.sh
@@ -3,7 +3,7 @@
 # After pulling the image, run this script to start the container.
 #
 # Usage:
-#   ./start-host-es.sh [--swarm] [--network <net>]
+#   ./start-host-es.sh [--network <net>]
 #
 # By default the script attaches the container to the "bridged-net" network.
 
@@ -15,48 +15,27 @@ fi
 
 NAME="enterprise-server"
 NETWORK="bridged-net"
-SWARM=0
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --swarm)
-            SWARM=1
-            shift
-            ;;
         --network)
             NETWORK="$2"
             shift 2
             ;;
         *)
-            echo "Usage: $0 [--swarm] [--network <net>]"
+            echo "Usage: $0 [--network <net>]"
             exit 1
             ;;
     esac
 done
 
-if [ $SWARM -eq 1 ]; then
-    if docker service create --help 2>&1 | grep -q -- "--platform"; then
-        PLATFORM_OPTION="--platform linux/amd64"
-    else
-        PLATFORM_OPTION=""
-    fi
-    docker service create --name "$NAME" \
-        --hostname "$NAME" \
-        --network "$NETWORK" \
-        $PLATFORM_OPTION \
-        --mount type=bind,source=/var/crash,target=/var/crash \
-        -e NSP_ACCEPT_EULA="Yes" \
-        --mount source=EnterpriseServer-db,target=/var/EBO \
-        ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
-else
-    docker run -d --network "$NETWORK" \
-        --platform linux/amd64 \
-        --ulimit core=-1 \
-        --restart always \
-        --mount type=bind,source=/var/crash,target=/var/crash \
-        -e NSP_ACCEPT_EULA="Yes" \
-        --mount source=EnterpriseServer-db,target=/var/EBO \
-        ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
-fi
+docker run -d --network "$NETWORK" \
+    --platform linux/amd64 \
+    --ulimit core=-1 \
+    --restart always \
+    --mount type=bind,source=/var/crash,target=/var/crash \
+    -e NSP_ACCEPT_EULA="Yes" \
+    --mount source=EnterpriseServer-db,target=/var/EBO \
+    ghcr.io/schneiderelectricbuildings/ebo-enterprise-server:7.0.2.348
 

--- a/user-scripts/teststart.py
+++ b/user-scripts/teststart.py
@@ -34,7 +34,6 @@ def get_arguments(description):
         "if not given the host environment variables https_proxy or HTTPS_PROXY will be used ")
     parser.add_argument('--no-proxy', default=None, help="optional no proxy " \
         "if not given the host environment variables no_proxy or NO_PROXY will be used ")
-    parser.add_argument('--swarm', action='store_true', help='create a Docker service instead of a standalone container')
     return parser.parse_args()
 
 def run():
@@ -77,34 +76,17 @@ def run():
         if "NO_PROXY" in os.environ:
             proxy += f'-e NO_PROXY={os.environ["NO_PROXY"]} '
 
-    if args.swarm:
-        platform_option = ''
-        try:
-            help_text = exe('docker service create --help')
-            if '--platform' in help_text:
-                platform_option = '--platform linux/amd64 '
-        except Exception:
-            pass
-
-        cmd = f'docker service create --name={name} --hostname {name} ' \
-            '--network bridged-net ' \
-            f'{platform_option}' \
-            f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
-            f'-e Semantic_Db_URL="{graphdb}" ' \
-            f'{proxy}'\
-            f'--mount source={db_vol},target={db_folder} '
-    else:
-        cmd = f'docker run -d --platform linux/amd64 --name={name} -h {name} ' \
-            '--ulimit core=-1 ' \
-            '--network bridged-net ' \
-            f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
-            f'-e Semantic_Db_URL="{graphdb}" ' \
-            f'{proxy}'\
-            f'--ip {ip} ' \
-            f'--mount source={db_vol},target={db_folder} '
+    cmd = f'docker run -d --platform linux/amd64 --name={name} -h {name} ' \
+        '--ulimit core=-1 ' \
+        '--network bridged-net ' \
+        f'-e NSP_ACCEPT_EULA="{accept_eula}" ' \
+        f'-e Semantic_Db_URL="{graphdb}" ' \
+        f'{proxy}'\
+        f'--ip {ip} ' \
+        f'--mount source={db_vol},target={db_folder} '
     if ca_folder:
         cmd += f'--mount type=bind,source={ca_folder},target=/usr/local/share/ca-certificates '
-    if dns and not args.swarm:
+    if dns:
         cmd += f'--dns {dns} '
     cmd += image
     exe(cmd)


### PR DESCRIPTION
## Summary
- remove Docker Swarm options from helper scripts
- delete Swarm references from documentation

## Testing
- `python3 -m py_compile user-scripts/*.py`
- `shellcheck user-scripts/start-host-es.sh user-scripts/start-graphdb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e3683f4883308767ca782272bf05